### PR TITLE
78 - entities refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,13 @@
             <version>3.5.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.instancio/instancio-junit -->
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-junit</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-inline -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/com/febfes/fftmback/domain/dao/ProjectEntity.java
+++ b/src/main/java/com/febfes/fftmback/domain/dao/ProjectEntity.java
@@ -1,11 +1,11 @@
 package com.febfes.fftmback.domain.dao;
 
 import com.febfes.fftmback.domain.dao.abstracts.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-
-import java.util.List;
 
 @Entity
 @Table(name = "project")
@@ -13,8 +13,8 @@ import java.util.List;
 @Setter
 @SuperBuilder
 @NoArgsConstructor
-@ToString(callSuper = true, exclude = {"taskColumnEntityList", "taskEntityList"})
-@EqualsAndHashCode(callSuper = true, exclude = {"taskColumnEntityList", "taskEntityList"})
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public class ProjectEntity extends BaseEntity {
 
     public static final String ENTITY_NAME = "Project";
@@ -24,17 +24,6 @@ public class ProjectEntity extends BaseEntity {
 
     @Column(name = "description")
     private String description;
-
-    @OneToMany(cascade = CascadeType.REMOVE)
-    @JoinColumn(name = "project_id")
-    private List<TaskColumnEntity> taskColumnEntityList;
-    //TODO problem when project was deleted
-    // TODO: rename to columns
-
-    @OneToMany(cascade = CascadeType.REMOVE)
-    @JoinColumn(name = "project_id")
-    private List<TaskEntity> taskEntityList;
-    //TODO problem when project was deleted
 
     @Column(name = "owner_id")
     private Long ownerId;

--- a/src/main/java/com/febfes/fftmback/domain/dao/TaskColumnEntity.java
+++ b/src/main/java/com/febfes/fftmback/domain/dao/TaskColumnEntity.java
@@ -1,11 +1,11 @@
 package com.febfes.fftmback.domain.dao;
 
 import com.febfes.fftmback.domain.dao.abstracts.OrderedEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-
-import java.util.List;
 
 @Entity
 @Table(name = "task_column")
@@ -24,11 +24,6 @@ public class TaskColumnEntity extends OrderedEntity {
 
     @Column(name = "project_id", nullable = false)
     private Long projectId;
-
-    @OneToMany(cascade = CascadeType.REMOVE)
-    @JoinColumn(name = "\"columnId\"")
-    @ToString.Exclude
-    private List<TaskView> taskList;
 
     @Override
     public String getColumnToFindOrder() {

--- a/src/main/java/com/febfes/fftmback/domain/dao/UserEntity.java
+++ b/src/main/java/com/febfes/fftmback/domain/dao/UserEntity.java
@@ -47,7 +47,7 @@ public class UserEntity extends BaseEntity implements UserDetails {
     @Column(name = "display_name")
     private String displayName;
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+    @OneToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "project_user_role",
             joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "id")},
             inverseJoinColumns = {@JoinColumn(name = "role_id", referencedColumnName = "id")})

--- a/src/main/java/com/febfes/fftmback/service/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/febfes/fftmback/service/impl/ProjectServiceImpl.java
@@ -65,7 +65,7 @@ public class ProjectServiceImpl implements ProjectService {
         columnService.createDefaultColumnsForProject(projectId);
         taskTypeService.createDefaultTaskTypesForProject(projectId);
         // by default, the owner will also be a member of the project
-        addOrChangeProjectMemberRole(project.getId(), userId, RoleName.OWNER);
+        addOrChangeProjectMemberRole(projectId, userId, RoleName.OWNER);
         return projectEntity;
     }
 

--- a/src/main/resources/db/changelog/changes/2023.10.01-add-cascade-delete.yaml
+++ b/src/main/resources/db/changelog/changes/2023.10.01-add-cascade-delete.yaml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: IvanShish
+      comment: "Add cascade delete"
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: task_column
+            constraintName: fk_column_project
+        - addForeignKeyConstraint:
+            baseColumnNames: project_id
+            baseTableName: task_column
+            constraintName: fk_column_project
+            onDelete: CASCADE
+            referencedColumnNames: id
+            referencedTableName: project
+            validate: true
+        - dropForeignKeyConstraint:
+            baseTableName: task
+            constraintName: fk_task_project
+        - addForeignKeyConstraint:
+            baseColumnNames: project_id
+            baseTableName: task
+            constraintName: fk_task_project
+            onDelete: CASCADE
+            referencedColumnNames: id
+            referencedTableName: project
+            validate: true

--- a/src/test/java/com/febfes/fftmback/integration/AuthenticationControllerTest.java
+++ b/src/test/java/com/febfes/fftmback/integration/AuthenticationControllerTest.java
@@ -9,25 +9,27 @@ import com.febfes.fftmback.service.RefreshTokenService;
 import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static io.restassured.RestAssured.given;
+import static org.instancio.Select.field;
 
 public class AuthenticationControllerTest extends BasicTestClass {
 
     public static final String PATH_TO_AUTH_API = "/api/v1/auth";
-    public static final String USER_USERNAME = "test_username";
-    public static final String USER_PASSWORD = "test_password";
-    public static final String USER_EMAIL = "test_email@febfes.com";
+    public static final String EMAIL_PATTERN = "#a#a#a#a#a#a@example.com";
 
     @Autowired
     RefreshTokenService refreshTokenService;
 
     @Test
     void successfulRegisterTest() {
-        UserDetailsDto userDetailsDto = new UserDetailsDto(USER_EMAIL, USER_USERNAME, USER_PASSWORD);
+        UserDetailsDto userDetailsDto = Instancio.of(UserDetailsDto.class)
+                .generate(field(UserDetailsDto::email), gen -> gen.text().pattern(EMAIL_PATTERN))
+                .create();
         registerUser(userDetailsDto)
                 .then()
                 .statusCode(HttpStatus.SC_OK);
@@ -35,12 +37,16 @@ public class AuthenticationControllerTest extends BasicTestClass {
 
     @Test
     void failedRegisterEmailAlreadyExistsTest() {
-        UserDetailsDto userDetailsDto = new UserDetailsDto(USER_EMAIL, USER_USERNAME, USER_PASSWORD);
+        UserDetailsDto userDetailsDto = Instancio.of(UserDetailsDto.class)
+                .generate(field(UserDetailsDto::email), gen -> gen.text().pattern(EMAIL_PATTERN))
+                .create();
         registerUser(userDetailsDto)
                 .then()
                 .statusCode(HttpStatus.SC_OK);
 
-        UserDetailsDto wrongEmailUserDetailsDto = new UserDetailsDto(USER_EMAIL, USER_USERNAME + "1", USER_PASSWORD);
+        UserDetailsDto wrongEmailUserDetailsDto = Instancio.of(UserDetailsDto.class)
+                .set(field(UserDetailsDto::email), userDetailsDto.email())
+                .create();
         registerUser(wrongEmailUserDetailsDto)
                 .then()
                 .statusCode(HttpStatus.SC_CONFLICT);
@@ -48,20 +54,26 @@ public class AuthenticationControllerTest extends BasicTestClass {
 
     @Test
     void failedRegisterUsernameAlreadyExistsTest() {
-        UserDetailsDto userDetailsDto = new UserDetailsDto(USER_EMAIL, USER_USERNAME, USER_PASSWORD);
+        UserDetailsDto userDetailsDto = Instancio.of(UserDetailsDto.class)
+                .generate(field(UserDetailsDto::email), gen -> gen.text().pattern(EMAIL_PATTERN))
+                .create();
         registerUser(userDetailsDto)
                 .then()
                 .statusCode(HttpStatus.SC_OK);
 
-        UserDetailsDto wrongEmailUserDetailsDto = new UserDetailsDto(USER_EMAIL + "1", USER_USERNAME, USER_PASSWORD);
+        UserDetailsDto wrongEmailUserDetailsDto = Instancio.of(UserDetailsDto.class)
+                .set(field(UserDetailsDto::username), userDetailsDto.username())
+                .create();
         registerUser(wrongEmailUserDetailsDto)
                 .then()
-                .statusCode(HttpStatus.SC_CONFLICT);
+                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
     }
 
     @Test
     void successfulAuthenticateTest() {
-        UserDetailsDto userDetailsDto = new UserDetailsDto(USER_EMAIL, USER_USERNAME, USER_PASSWORD);
+        UserDetailsDto userDetailsDto = Instancio.of(UserDetailsDto.class)
+                .generate(field(UserDetailsDto::email), gen -> gen.text().pattern(EMAIL_PATTERN))
+                .create();
 
         registerUser(userDetailsDto)
                 .then()
@@ -117,7 +129,9 @@ public class AuthenticationControllerTest extends BasicTestClass {
     }
 
     private GetAuthDto getRefreshTokenDto() {
-        UserDetailsDto userDetailsDto = new UserDetailsDto(USER_EMAIL, USER_USERNAME, USER_PASSWORD);
+        UserDetailsDto userDetailsDto = Instancio.of(UserDetailsDto.class)
+                .generate(field(UserDetailsDto::email), gen -> gen.text().pattern(EMAIL_PATTERN))
+                .create();
 
         registerUser(userDetailsDto)
                 .then()

--- a/src/test/java/com/febfes/fftmback/integration/BasicTestClass.java
+++ b/src/test/java/com/febfes/fftmback/integration/BasicTestClass.java
@@ -1,8 +1,15 @@
 package com.febfes.fftmback.integration;
 
 
+import com.febfes.fftmback.domain.dao.ProjectEntity;
+import com.febfes.fftmback.domain.dao.UserEntity;
+import com.febfes.fftmback.service.AuthenticationService;
+import com.febfes.fftmback.service.ProjectService;
+import com.febfes.fftmback.service.UserService;
 import com.febfes.fftmback.util.DatabaseCleanup;
+import com.febfes.fftmback.util.DtoBuilders;
 import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +22,9 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static com.febfes.fftmback.util.DtoBuilders.PASSWORD;
+import static io.restassured.RestAssured.given;
+
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
@@ -24,11 +34,23 @@ public class BasicTestClass {
     @Autowired
     private DatabaseCleanup databaseCleanup;
 
+    @Autowired
+    protected AuthenticationService authenticationService;
+
+    @Autowired
+    protected UserService userService;
+
+    @Autowired
+    protected ProjectService projectService;
+
     @LocalServerPort
     private Integer port;
 
     @Container
     static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:14-alpine");
+
+    protected String token;
+    protected Long createdUserId;
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {
@@ -39,11 +61,33 @@ public class BasicTestClass {
     @BeforeEach
     void setUp() {
         RestAssured.baseURI = "http://localhost:" + port;
+
+        UserEntity user = DtoBuilders.createUser();
+        authenticationService.registerUser(user);
+        createdUserId = userService.getUserIdByUsername(user.getUsername());
+        token = authenticationService.authenticateUser(
+                UserEntity.builder().username(user.getUsername()).encryptedPassword(PASSWORD).build()
+        ).accessToken();
     }
 
     @AfterEach
     void afterEach() {
         databaseCleanup.execute();
+    }
+
+    protected RequestSpecification requestWithBearerToken() {
+        return given().header("Authorization", "Bearer " + token);
+    }
+
+    protected Long createNewUser() {
+        UserEntity user = DtoBuilders.createUser();
+        authenticationService.registerUser(user);
+        return userService.getUserIdByUsername(user.getUsername());
+    }
+
+    protected Long createNewProject() {
+        ProjectEntity project = DtoBuilders.createProject(createdUserId);
+        return projectService.createProject(project, createdUserId).getId();
     }
 }
 

--- a/src/test/java/com/febfes/fftmback/integration/DashboardControllerTests.java
+++ b/src/test/java/com/febfes/fftmback/integration/DashboardControllerTests.java
@@ -1,38 +1,22 @@
 package com.febfes.fftmback.integration;
 
 
-import com.febfes.fftmback.domain.dao.ProjectEntity;
 import com.febfes.fftmback.domain.dao.TaskColumnEntity;
 import com.febfes.fftmback.domain.dao.TaskEntity;
-import com.febfes.fftmback.domain.dao.UserEntity;
 import com.febfes.fftmback.dto.ColumnWithTasksDto;
 import com.febfes.fftmback.dto.DashboardDto;
-import com.febfes.fftmback.service.*;
+import com.febfes.fftmback.service.ColumnService;
+import com.febfes.fftmback.service.TaskService;
 import com.febfes.fftmback.util.DtoBuilders;
 import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static com.febfes.fftmback.integration.AuthenticationControllerTest.*;
-import static io.restassured.RestAssured.given;
-
 
 class DashboardControllerTests extends BasicTestClass {
-
-    private static final String PROJECT_NAME = "Project name";
-    private static final String COLUMN_NAME = "Column name";
-    private static final String TASK_NAME = "Task name";
-
-    private Long createdUserId;
-    private String token;
-
-    @Autowired
-    private ProjectService projectService;
 
     @Autowired
     private ColumnService columnService;
@@ -40,98 +24,61 @@ class DashboardControllerTests extends BasicTestClass {
     @Autowired
     private TaskService taskService;
 
-    @Autowired
-    private AuthenticationService authenticationService;
-
-    @Autowired
-    private UserService userService;
-
-    @BeforeEach
-    void beforeEach() {
-        authenticationService.registerUser(
-                UserEntity.builder().email(USER_EMAIL).username(USER_USERNAME).encryptedPassword(USER_PASSWORD).build()
-        );
-        token = authenticationService.authenticateUser(
-                UserEntity.builder().username(USER_USERNAME).encryptedPassword(USER_PASSWORD).build()
-        ).accessToken();
-        createdUserId = userService.getUserIdByUsername(USER_USERNAME);
-    }
-
     @Test
     void successfulGetDashboardTest() {
-        ProjectEntity projectEntity = projectService.createProject(
-                ProjectEntity.builder().name(PROJECT_NAME).build(),
-                createdUserId
-        );
-        TaskColumnEntity columnEntity = columnService.createColumn(TaskColumnEntity
-                        .builder()
-                        .name(COLUMN_NAME)
-                        .projectId(projectEntity.getId())
-                        .build()
-        );
-        taskService.createTask(
-                TaskEntity
-                        .builder()
-                        .projectId(projectEntity.getId())
-                        .columnId(columnEntity.getId())
-                        .name(TASK_NAME)
-                        .build(),
-                createdUserId
-        );
+        Long projectId = createNewProject();
+        TaskColumnEntity columnEntity = columnService.createColumn(DtoBuilders.createColumn(projectId));
+        TaskEntity task = DtoBuilders.createTask(projectId, columnEntity.getId());
+        taskService.createTask(task, createdUserId);
 
         DashboardDto dashboardDto = requestWithBearerToken()
                 .contentType(ContentType.JSON)
                 .when()
-                .get("/api/v1/projects/{id}/dashboard", projectEntity.getId())
+                .get("/api/v1/projects/{id}/dashboard", projectId)
                 .then()
-                .statusCode(200)
+                .statusCode(HttpStatus.SC_OK)
                 .extract()
                 .response()
                 .as(DashboardDto.class);
         ColumnWithTasksDto createdColumn = dashboardDto.columns().get(4);
-        Assertions.assertEquals(COLUMN_NAME, createdColumn.name());
-        Assertions.assertEquals(TASK_NAME, createdColumn.tasks().get(0).name());
+        Assertions.assertEquals(columnEntity.getName(), createdColumn.name());
+        Assertions.assertEquals(task.getName(), createdColumn.tasks().get(0).name());
     }
 
     @Test
     void successfulGetDashboardWithFilterTest() {
-        Long projectId = projectService.createProject(
-                ProjectEntity.builder().name(PROJECT_NAME).build(),
-                createdUserId
-        ).getId();
+        Long projectId = createNewProject();
+        String taskName = "task_name";
         taskService.createTask(
-                DtoBuilders.createTaskEntity(projectId, 1L, TASK_NAME),
+                DtoBuilders.createTask(projectId, 1L, taskName),
                 createdUserId
         );
         taskService.createTask(
-                DtoBuilders.createTaskEntity(projectId, 1L, TASK_NAME + "2"),
+                DtoBuilders.createTask(projectId, 1L, taskName + "2"),
                 createdUserId
         );
         taskService.createTask(
-                DtoBuilders.createTaskEntity(projectId, 1L, "2"),
+                DtoBuilders.createTask(projectId, 1L, "2"),
                 createdUserId
         );
         taskService.createTask(
-                DtoBuilders.createTaskEntity(projectId, 2L, TASK_NAME + "3"),
+                DtoBuilders.createTask(projectId, 2L, taskName + "3"),
                 createdUserId
         );
         taskService.createTask(
-                DtoBuilders.createTaskEntity(projectId, 3L, "3"),
+                DtoBuilders.createTask(projectId, 3L, "3"),
                 createdUserId
         );
 
-        Long projectId2 = projectService.createProject(
-                ProjectEntity.builder().name(PROJECT_NAME + "2").build(),
-                createdUserId
-        ).getId();
+        Long projectId2 = createNewProject();
         taskService.createTask(
-                DtoBuilders.createTaskEntity(projectId2, 5L, TASK_NAME),
+                DtoBuilders.createTask(projectId2, 5L, taskName),
                 createdUserId
         );
 
         Response response = requestWithBearerToken()
                 .contentType(ContentType.JSON)
-                .params("taskName", TASK_NAME)
+                .params("taskName", taskName)
                 .when()
                 .get("/api/v1/projects/{id}/dashboard", projectId);
         DashboardDto dashboardDto = response.then()
@@ -140,9 +87,5 @@ class DashboardControllerTests extends BasicTestClass {
                 .response()
                 .as(DashboardDto.class);
         Assertions.assertEquals(2, dashboardDto.columns().get(0).tasks().size());
-    }
-
-    private RequestSpecification requestWithBearerToken() {
-        return given().header("Authorization", "Bearer " + token);
     }
 }

--- a/src/test/java/com/febfes/fftmback/integration/MemberControllerTest.java
+++ b/src/test/java/com/febfes/fftmback/integration/MemberControllerTest.java
@@ -1,0 +1,105 @@
+package com.febfes.fftmback.integration;
+
+import com.febfes.fftmback.dto.MemberDto;
+import com.febfes.fftmback.dto.ProjectDto;
+import com.febfes.fftmback.service.ProjectService;
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
+import io.restassured.http.ContentType;
+import io.restassured.mapper.TypeRef;
+import lombok.NonNull;
+import org.apache.commons.compress.utils.Lists;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.febfes.fftmback.integration.ProjectControllerTest.PATH_TO_PROJECTS_API;
+
+class MemberControllerTest extends BasicTestClass {
+
+    @Autowired
+    TransactionTemplate txTemplate;
+
+    @Autowired
+    ProjectService projectService;
+
+    @Test
+    void successfulAddNewMembersTest() {
+        Long secondCreatedUserId = createNewUser();
+        Long thirdCreatedUserId = createNewUser();
+        Long createdProjectId = createNewProject();
+        addMembers(List.of(secondCreatedUserId, thirdCreatedUserId), createdProjectId);
+
+        // it's to avoid org.hibernate.LazyInitializationException
+        txTemplate.execute(new TransactionCallbackWithoutResult() {
+
+            @Override
+            protected void doInTransactionWithoutResult(@NonNull TransactionStatus status) {
+                List<MemberDto> members = userService.getProjectMembersWithRole(createdProjectId);
+                // as owner is also a member
+                Assertions.assertThat(members).hasSize(3);
+                List<ProjectDto> secondUserProjects =
+                        projectService.getProjectsForUser(secondCreatedUserId, Lists.newArrayList());
+                Assertions.assertThat(secondUserProjects).hasSize(1);
+                List<ProjectDto> thirdUserProjects =
+                        projectService.getProjectsForUser(thirdCreatedUserId, Lists.newArrayList());
+                Assertions.assertThat(thirdUserProjects).hasSize(1);
+            }
+        });
+    }
+
+    @Test
+    void successfulRemoveMemberTest() {
+        Long secondCreatedUserId = createNewUser();
+        Long createdProjectId = createNewProject();
+        addMembers(List.of(secondCreatedUserId), createdProjectId);
+        requestWithBearerToken()
+                .contentType(ContentType.JSON)
+                .when()
+                .delete("%s/{id}/members/{memberId}".formatted(PATH_TO_PROJECTS_API), createdProjectId, secondCreatedUserId)
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+
+        List<MemberDto> members = userService.getProjectMembersWithRole(createdProjectId);
+        Assertions.assertThat(members).hasSize(1);
+        List<ProjectDto> secondMemberProjects = projectService.getProjectsForUser(secondCreatedUserId, Lists.newArrayList());
+        Assertions.assertThat(secondMemberProjects).isEmpty();
+    }
+
+    @Test
+    void successfulGetMembersTest() {
+        Long secondCreatedUserId = createNewUser();
+        Long createdProjectId = createNewProject();
+        addMembers(List.of(secondCreatedUserId), createdProjectId);
+        List<MemberDto> projectMembers = requestWithBearerToken()
+                .contentType(ContentType.JSON)
+                .when()
+                .get("%s/{id}/members".formatted(PATH_TO_PROJECTS_API), createdProjectId)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract()
+                .response()
+                .as(new TypeRef<>() {
+                });
+        Assertions.assertThat(projectMembers).hasSize(2);
+        Optional<MemberDto> projectMember = projectMembers.stream().findFirst();
+        Assertions.assertThat(projectMember)
+                .isNotEmpty();
+        Assertions.assertThat(projectMember.get().roleOnProject()).isNotNull();
+    }
+
+    private void addMembers(List<Long> memberIds, Long projectId) {
+        requestWithBearerToken()
+                .contentType(ContentType.JSON)
+                .body(memberIds)
+                .when()
+                .post("%s/{id}/members".formatted(PATH_TO_PROJECTS_API), projectId)
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+}

--- a/src/test/java/com/febfes/fftmback/integration/TaskFilterTest.java
+++ b/src/test/java/com/febfes/fftmback/integration/TaskFilterTest.java
@@ -10,7 +10,9 @@ import com.febfes.fftmback.service.AuthenticationService;
 import com.febfes.fftmback.service.ProjectService;
 import com.febfes.fftmback.service.TaskService;
 import com.febfes.fftmback.service.UserService;
+import com.febfes.fftmback.util.DtoBuilders;
 import net.kaczmarzyk.spring.data.jpa.utils.SpecificationBuilder;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,11 +22,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.stream.Stream;
 
-import static com.febfes.fftmback.integration.AuthenticationControllerTest.*;
-import static com.febfes.fftmback.integration.ProjectControllerTest.PROJECT_NAME;
-import static com.febfes.fftmback.integration.TaskControllerTest.TASK_NAME;
-
 class TaskFilterTest extends BasicStaticDataTestClass {
+
+    private static final String TASK_NAME = "task name";
 
     @Autowired
     private TaskViewRepository taskViewRepository;
@@ -36,30 +36,18 @@ class TaskFilterTest extends BasicStaticDataTestClass {
             @Autowired ProjectService projectService,
             @Autowired TaskService taskService
     ) {
-        authenticationService.registerUser(
-                UserEntity.builder().email(USER_EMAIL).username(USER_USERNAME).encryptedPassword(USER_PASSWORD).build()
-        );
-        Long createdUserId = userService.getUserIdByUsername(USER_USERNAME);
+        UserEntity user = DtoBuilders.createUser();
+        authenticationService.registerUser(user);
+        Long createdUserId = userService.getUserIdByUsername(user.getUsername());
 
-        authenticationService.registerUser(UserEntity
-                .builder()
-                .email("new_" + USER_EMAIL)
-                .username("new" + USER_USERNAME)
-                .encryptedPassword(USER_PASSWORD)
-                .build()
-        );
-        Long createdUserId2 = userService.getUserIdByUsername("new" + USER_USERNAME);
+        UserEntity user2 = DtoBuilders.createUser();
+        authenticationService.registerUser(user2);
+        Long createdUserId2 = userService.getUserIdByUsername(user2.getUsername());
 
-        ProjectEntity projectEntity = projectService.createProject(
-                ProjectEntity.builder().name(PROJECT_NAME).build(),
-                createdUserId
-        );
+        ProjectEntity projectEntity = projectService.createProject(Instancio.create(ProjectEntity.class), createdUserId);
         Long createdProjectId = projectEntity.getId();
 
-        ProjectEntity projectEntity2 = projectService.createProject(
-                ProjectEntity.builder().name(PROJECT_NAME).build(),
-                createdUserId2
-        );
+        ProjectEntity projectEntity2 = projectService.createProject(Instancio.create(ProjectEntity.class), createdUserId2);
         Long createdProjectId2 = projectEntity2.getId();
 
         taskService.createTask(

--- a/src/test/java/com/febfes/fftmback/integration/UserControllerTest.java
+++ b/src/test/java/com/febfes/fftmback/integration/UserControllerTest.java
@@ -6,15 +6,12 @@ import com.febfes.fftmback.dto.EditUserDto;
 import com.febfes.fftmback.dto.UserDto;
 import com.febfes.fftmback.dto.UserPicDto;
 import com.febfes.fftmback.exception.EntityNotFoundException;
-import com.febfes.fftmback.service.AuthenticationService;
 import com.febfes.fftmback.service.FileService;
-import com.febfes.fftmback.service.UserService;
 import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
 import io.restassured.http.ContentType;
 import io.restassured.mapper.TypeRef;
-import io.restassured.specification.RequestSpecification;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,31 +29,16 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static com.febfes.fftmback.integration.AuthenticationControllerTest.*;
 import static com.febfes.fftmback.util.FileUtils.USER_PIC_URN;
-import static io.restassured.RestAssured.given;
 import static java.util.Objects.nonNull;
 import static org.hamcrest.Matchers.equalTo;
 
 class UserControllerTest extends BasicTestClass {
 
     public static final String PATH_TO_USERS_API = "/api/v1/users";
-    private static final String FIRST_NAME = "first";
-    private static final String LAST_NAME = "last";
-    private static final String DISPLAY_NAME = "display";
-    private static final String PASSWORD = "123";
-
-    private String createdUsername;
-    private String token;
 
     @TempDir
     static File tempDir;
-
-    @Autowired
-    private UserService userService;
-
-    @Autowired
-    private AuthenticationService authenticationService;
 
     @Autowired
     private FileService fileService;
@@ -71,41 +53,29 @@ class UserControllerTest extends BasicTestClass {
         );
     }
 
-    @BeforeEach
-    void beforeEach() {
-        authenticationService.registerUser(
-                UserEntity.builder().email(USER_EMAIL).username(USER_USERNAME).encryptedPassword(USER_PASSWORD).build()
-        );
-        token = authenticationService.authenticateUser(
-                UserEntity.builder().username(USER_USERNAME).encryptedPassword(USER_PASSWORD).build()
-        ).accessToken();
-        createdUsername = USER_USERNAME;
-    }
-
     @Test
     void successfulGetUserTest() {
-        Long userId = userService.getUserIdByUsername(createdUsername);
+        UserEntity user = userService.getUserById(createdUserId);
         requestWithBearerToken()
                 .contentType(ContentType.JSON)
                 .when()
-                .get("%s/{id}".formatted(PATH_TO_USERS_API), userId)
+                .get("%s/{id}".formatted(PATH_TO_USERS_API), createdUserId)
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("username", equalTo(createdUsername));
+                .body("username", equalTo(user.getUsername()));
     }
 
     @ParameterizedTest
     @MethodSource("updateUserData")
     void successfulUpdateUserTest(EditUserDto editUserDto) {
-        Long userId = userService.getUserIdByUsername(createdUsername);
         requestWithBearerToken()
                 .contentType(ContentType.JSON)
                 .body(editUserDto)
                 .when()
-                .put("%s/{id}".formatted(PATH_TO_USERS_API), userId)
+                .put("%s/{id}".formatted(PATH_TO_USERS_API), createdUserId)
                 .then()
                 .statusCode(HttpStatus.SC_OK);
-        UserEntity user = userService.getUserById(userId);
+        UserEntity user = userService.getUserById(createdUserId);
         Assertions.assertEquals(editUserDto.firstName(), user.getFirstName());
         Assertions.assertEquals(editUserDto.lastName(), user.getLastName());
         Assertions.assertEquals(editUserDto.displayName(), user.getDisplayName());
@@ -118,45 +88,35 @@ class UserControllerTest extends BasicTestClass {
 
     static Stream<Arguments> updateUserData() {
         return Stream.of(
-                Arguments.of(new EditUserDto(FIRST_NAME, LAST_NAME, DISPLAY_NAME, PASSWORD), 3),
-                Arguments.of(new EditUserDto(FIRST_NAME, LAST_NAME, DISPLAY_NAME, null), 1)
+                Arguments.of(Instancio.create(EditUserDto.class), 3),
+                Arguments.of(Instancio.create(EditUserDto.class), 1)
         );
     }
 
     @Test
     void successfulLoadUserPicTest() {
-        Long userId = userService.getUserIdByUsername(createdUsername);
-        File imageFile = new File("src/test/resources/image.jpg");
-        UserPicDto userPicDto = requestWithBearerToken()
-                .multiPart("image", imageFile, "multipart/form-data")
-                .when()
-                .post("/api/v1/files/user-pic/{userId}", userId)
-                .then()
-                .statusCode(HttpStatus.SC_OK)
-                .extract()
-                .response()
-                .as(UserPicDto.class);
-        Assertions.assertEquals("/files/user-pic/%d".formatted(userId), userPicDto.fileUrn());
-        Assertions.assertEquals(userId, userPicDto.userId());
+        UserPicDto userPicDto = loadUserPic();
+        Assertions.assertEquals("/files/user-pic/%d".formatted(createdUserId), userPicDto.fileUrn());
+        Assertions.assertEquals(createdUserId, userPicDto.userId());
     }
 
     @Test
     void successfulGetUserPicTest() throws IOException {
-        Long userId = userService.getUserIdByUsername(createdUsername);
         MultipartFile file = new MockMultipartFile("image.jpg", "image", "jpg", new byte[]{1});
-        fileService.saveFile(userId, userId, EntityType.USER_PIC, file);
+        fileService.saveFile(createdUserId, createdUserId, EntityType.USER_PIC, file);
         requestWithBearerToken()
                 .when()
-                .get("/api/v1/files/user-pic/{userId}", userId)
+                .get("/api/v1/files/user-pic/{userId}", createdUserId)
                 .then()
                 .statusCode(HttpStatus.SC_OK);
     }
 
     @Test
     void successfulGetUsersWithFilterTest() {
+        UserEntity user = userService.getUserById(createdUserId);
         List<UserDto> users = requestWithBearerToken()
                 .contentType(ContentType.JSON)
-                .params("displayName", "user")
+                .params("displayName", user.getDisplayName())
                 .when()
                 .get(PATH_TO_USERS_API)
                 .then()
@@ -170,39 +130,45 @@ class UserControllerTest extends BasicTestClass {
 
     @Test
     void successfulGetUserPicFromUserInfoTest() {
-        successfulLoadUserPicTest();
-        Long userId = userService.getUserIdByUsername(createdUsername);
+        loadUserPic();
         UserDto userDto = requestWithBearerToken()
                 .when()
-                .get("%s/{id}".formatted(PATH_TO_USERS_API), userId)
+                .get("%s/{id}".formatted(PATH_TO_USERS_API), createdUserId)
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .extract()
                 .response()
                 .as(UserDto.class);
         Assertions.assertNotNull(userDto.userPic());
-        Assertions.assertEquals(String.format(USER_PIC_URN, userId), userDto.userPic());
+        Assertions.assertEquals(String.format(USER_PIC_URN, createdUserId), userDto.userPic());
     }
 
     @Test
     void successfulDeleteUserPicTest() {
-        successfulLoadUserPicTest();
-        Long userId = userService.getUserIdByUsername(createdUsername);
+        loadUserPic();
         requestWithBearerToken()
                 .when()
-                .delete("/api/v1/files/user-pic/{userId}", userId)
+                .delete("/api/v1/files/user-pic/{userId}", createdUserId)
                 .then()
                 .statusCode(HttpStatus.SC_OK);
-        String userPicUrn = String.format(USER_PIC_URN, userId);
+        String userPicUrn = String.format(USER_PIC_URN, createdUserId);
         Assertions.assertThrows(
                 EntityNotFoundException.class,
                 () -> fileService.getFile(userPicUrn)
         );
     }
 
-
-    private RequestSpecification requestWithBearerToken() {
-        return given().header("Authorization", "Bearer " + token);
+    private UserPicDto loadUserPic() {
+        File imageFile = new File("src/test/resources/image.jpg");
+        return requestWithBearerToken()
+                .multiPart("image", imageFile, "multipart/form-data")
+                .when()
+                .post("/api/v1/files/user-pic/{userId}", createdUserId)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract()
+                .response()
+                .as(UserPicDto.class);
     }
 
 }

--- a/src/test/java/com/febfes/fftmback/integration/UserFilterTest.java
+++ b/src/test/java/com/febfes/fftmback/integration/UserFilterTest.java
@@ -1,9 +1,9 @@
 package com.febfes.fftmback.integration;
 
 import com.febfes.fftmback.domain.common.specification.UserSpec;
-import com.febfes.fftmback.domain.dao.UserEntity;
 import com.febfes.fftmback.repository.UserViewRepository;
 import com.febfes.fftmback.service.AuthenticationService;
+import com.febfes.fftmback.util.DtoBuilders;
 import net.kaczmarzyk.spring.data.jpa.utils.SpecificationBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -13,8 +13,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.stream.Stream;
-
-import static com.febfes.fftmback.integration.AuthenticationControllerTest.*;
 
 public class UserFilterTest extends BasicStaticDataTestClass {
 
@@ -27,16 +25,11 @@ public class UserFilterTest extends BasicStaticDataTestClass {
     static void beforeAll(
             @Autowired AuthenticationService authenticationService
     ) {
-        authenticationService.registerUser(UserEntity.builder().email(USER_EMAIL).username(USER_USERNAME)
-                .encryptedPassword(USER_PASSWORD).displayName(USER_DISPLAY_NAME).build());
-        authenticationService.registerUser(UserEntity.builder().email(USER_EMAIL + "1").username(USER_USERNAME + "1")
-                .encryptedPassword(USER_PASSWORD).displayName("123" + USER_DISPLAY_NAME).build());
-        authenticationService.registerUser(UserEntity.builder().email(USER_EMAIL + "2").username(USER_USERNAME + "2")
-                .encryptedPassword(USER_PASSWORD).displayName(USER_DISPLAY_NAME + "456").build());
-        authenticationService.registerUser(UserEntity.builder().email(USER_EMAIL + "3").username(USER_USERNAME + "3")
-                .encryptedPassword(USER_PASSWORD).displayName("1256").build());
-        authenticationService.registerUser(UserEntity.builder().email(USER_EMAIL + "4").username(USER_USERNAME + "4")
-                .encryptedPassword(USER_PASSWORD).displayName("something").build());
+        authenticationService.registerUser(DtoBuilders.createUser(USER_DISPLAY_NAME));
+        authenticationService.registerUser(DtoBuilders.createUser("123" + USER_DISPLAY_NAME));
+        authenticationService.registerUser(DtoBuilders.createUser(USER_DISPLAY_NAME + "456"));
+        authenticationService.registerUser(DtoBuilders.createUser("1256"));
+        authenticationService.registerUser(DtoBuilders.createUser("something"));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/febfes/fftmback/util/DtoBuilders.java
+++ b/src/test/java/com/febfes/fftmback/util/DtoBuilders.java
@@ -1,35 +1,23 @@
 package com.febfes.fftmback.util;
 
-import com.febfes.fftmback.domain.common.TaskPriority;
-import com.febfes.fftmback.domain.dao.TaskEntity;
+import com.febfes.fftmback.domain.dao.*;
 import com.febfes.fftmback.dto.ColumnDto;
-import com.febfes.fftmback.dto.ProjectDto;
-import com.febfes.fftmback.dto.TaskDto;
+import com.febfes.fftmback.dto.EditTaskDto;
 import lombok.experimental.UtilityClass;
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
 import org.springframework.context.annotation.Profile;
+
+import java.util.Collections;
+
+import static com.febfes.fftmback.integration.AuthenticationControllerTest.EMAIL_PATTERN;
+import static org.instancio.Select.field;
 
 @UtilityClass
 @Profile("test")
 public class DtoBuilders {
 
-    public ProjectDto createProjectDto(String name) {
-        return ProjectDto.builder()
-                .name(name)
-                .build();
-    }
-
-    public ProjectDto createProjectDto(String name, String description) {
-        return ProjectDto.builder()
-                .name(name)
-                .description(description)
-                .build();
-    }
-
-    public ColumnDto createColumnDto(String name) {
-        return ColumnDto.builder()
-                .name(name)
-                .build();
-    }
+    public static final String PASSWORD = "password";
 
     public ColumnDto createColumnDto(String name, Integer order) {
         return ColumnDto.builder()
@@ -38,30 +26,74 @@ public class DtoBuilders {
                 .build();
     }
 
-    public TaskDto createTaskDto(String name) {
-        return TaskDto.builder()
-                .name(name)
-                .filesCounter(0L)
-                .build();
+    public static UserEntity createUser() {
+        return commonUser().create();
     }
 
-    public TaskDto createTaskDtoWithType(String name, String type) {
-        return TaskDto.builder()
-                .name(name)
-                .type(type)
-                .filesCounter(0L)
-                .build();
+    public static UserEntity createUser(String displayName) {
+        return commonUser()
+                .set(field(UserEntity::getDisplayName), displayName)
+                .create();
     }
 
-    public TaskDto createTaskDtoWithPriority(String name, String priority) {
-        return TaskDto.builder()
-                .name(name)
-                .filesCounter(0L)
-                .priority(TaskPriority.valueOf(priority.toUpperCase()))
-                .build();
+    public static TaskColumnEntity createColumn(Long projectId) {
+        return Instancio.of(TaskColumnEntity.class)
+                .set(field(TaskColumnEntity::getProjectId), projectId)
+                .create();
     }
 
-    public TaskEntity createTaskEntity(Long projectId, Long columnId, String taskName) {
-        return TaskEntity.builder().projectId(projectId).columnId(columnId).name(taskName).build();
+    public static TaskEntity createTask(Long projectId, Long columnId) {
+        return commonTask(projectId, columnId).create();
+    }
+
+    public static TaskEntity createTask(Long projectId, Long columnId, String taskName) {
+        return commonTask(projectId, columnId)
+                .set(field(TaskEntity::getName), taskName)
+                .create();
+    }
+
+    public static ProjectEntity createProject(String name) {
+        return Instancio.of(ProjectEntity.class)
+                .set(field(ProjectEntity::getName), name)
+                .create();
+    }
+
+    public static ProjectEntity createProject(Long userId) {
+        return Instancio.of(ProjectEntity.class)
+                .set(field(ProjectEntity::getOwnerId), userId)
+                .create();
+    }
+
+    public static TaskTypeEntity createTaskType(Long projectId) {
+        return Instancio.of(TaskTypeEntity.class)
+                .set(field(TaskTypeEntity::getProjectId), projectId)
+                .create();
+    }
+
+    public static EditTaskDto createEditTaskDto(Integer order) {
+        return commonEditTask()
+                .set(field(EditTaskDto::order), order)
+                .create();
+    }
+
+    private InstancioApi<UserEntity> commonUser() {
+        return Instancio.of(UserEntity.class)
+                .generate(field(UserEntity::getEmail), gen -> gen.text().pattern(EMAIL_PATTERN))
+                .set(field(UserEntity::getProjectRoles), Collections.emptyMap())
+                .set(field(UserEntity::getEncryptedPassword), PASSWORD);
+    }
+
+    private InstancioApi<TaskEntity> commonTask(Long projectId, Long columnId) {
+        return Instancio.of(TaskEntity.class)
+                .set(field(TaskEntity::getProjectId), projectId)
+                .set(field(TaskEntity::getColumnId), columnId)
+                .set(field(TaskEntity::getAssigneeId), null)
+                .set(field(TaskEntity::getOwnerId), null)
+                .set(field(TaskEntity::getTaskType), null);
+    }
+
+    private InstancioApi<EditTaskDto> commonEditTask() {
+        return Instancio.of(EditTaskDto.class)
+                .set(field(EditTaskDto::assigneeId), null);
     }
 }


### PR DESCRIPTION
Здесь же немного отрефакторил тесты https://github.com/FEBFES/FF-TM-BACK/issues/177 с использованием новой библиотеки. Проекты и юзеров не получилось сохранять через репозиторий, потому что в методе в сервисе происходят важные штуки, которые если мокать, то надо повозиться. И в общем проще так было оставить пока)

https://github.com/FEBFES/FF-TM-BACK/issues/78 по этому issue удалил неиспользуемые переменные в ProjectEntity и TaskColumnEntity. Добавил каскадное удаление, чтобы если удалялся проект - удалались колонки в этом проекте и таски. При этом, если удаляется колонка, то таски не должны удаляться (в будущем хотелось бы, чтобы они в какую-то дефолтную колонку сваливались). Хотя я этого даже не проверял))). А то что при удалении проекта все удаляется - это в `ProjectControllerTest.successfulDeleteOfProjectTest()`